### PR TITLE
Always export function rather than constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Blob
 ====
 
-A module that exports a constructor that uses `window.Blob` when available,
+A module that exports a function that uses `window.Blob` when available,
 and a `BlobBuilder` with any vendor prefix in other cases.
 
 If neither is available, it exports `undefined`.
@@ -19,8 +19,8 @@ Example
 -------
 
 ``` js
-var Blob = require('blob');
-var b = new Blob(['hi', 'constructing', 'a', 'blob']);
+var blob = require('blob');
+var b = blob(['hi', 'constructing', 'a', 'blob']);
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -79,13 +79,17 @@ function BlobBuilderConstructor(ary, options) {
   return (options.type) ? bb.getBlob(options.type) : bb.getBlob();
 };
 
-function BlobConstructor(ary, options) {
+function BlobArrayBufferViewSupportConstructor(ary, options) {
   return new Blob(mapArrayBufferViews(ary), options || {});
+};
+
+function BlobConstructor(ary, options) {
+  return new Blob(ary, options || {});
 };
 
 module.exports = (function() {
   if (blobSupported) {
-    return blobSupportsArrayBufferView ? global.Blob : BlobConstructor;
+    return blobSupportsArrayBufferView ? BlobConstructor : BlobArrayBufferViewSupportConstructor;
   } else if (blobBuilderSupported) {
     return BlobBuilderConstructor;
   } else {

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,8 @@
-var Blob = require('../');
+var blob = require('../');
 var expect = require('expect.js');
 
 describe('blob', function() {
-  if (!Blob) {
+  if (!blob) {
     it('should not have a blob or a blob builder in the global namespace, or blob should not be a constructor function if the module exports false', function() {
       try {
         var ab = (new Uint8Array(5)).buffer;
@@ -18,19 +18,19 @@ describe('blob', function() {
     });
   } else {
     it('should encode a proper sized blob when given a string argument', function() {
-      var b = new Blob(['hi']);
+      var b = blob(['hi']);
       expect(b.size).to.be(2);
     });
 
     it('should encode a blob with proper size when given two strings as arguments', function() {
-      var b = new Blob(['hi', 'hello']);
+      var b = blob(['hi', 'hello']);
       expect(b.size).to.be(7);
     });
 
     it('should encode arraybuffers with right content', function(done) {
       var ary = new Uint8Array(5);
       for (var i = 0; i < 5; i++) ary[i] = i;
-      var b = new Blob([ary.buffer]);
+      var b = blob([ary.buffer]);
       var fr = new FileReader();
       fr.onload = function() {
         var newAry = new Uint8Array(this.result);
@@ -43,7 +43,7 @@ describe('blob', function() {
     it('should encode typed arrays with right content', function(done) {
       var ary = new Uint8Array(5);
       for (var i = 0; i < 5; i++) ary[i] = i;
-      var b = new Blob([ary]);
+      var b = blob([ary]);
       var fr = new FileReader();
       fr.onload = function() {
         var newAry = new Uint8Array(this.result);
@@ -56,7 +56,7 @@ describe('blob', function() {
     it('should encode sliced typed arrays with right content', function(done) {
       var ary = new Uint8Array(5);
       for (var i = 0; i < 5; i++) ary[i] = i;
-      var b = new Blob([ary.subarray(2)]);
+      var b = blob([ary.subarray(2)]);
       var fr = new FileReader();
       fr.onload = function() {
         var newAry = new Uint8Array(this.result);
@@ -69,7 +69,7 @@ describe('blob', function() {
     it('should encode with blobs', function(done) {
       var ary = new Uint8Array(5);
       for (var i = 0; i < 5; i++) ary[i] = i;
-      var b = new Blob([new Blob([ary.buffer])]);
+      var b = blob([blob([ary.buffer])]);
       var fr = new FileReader();
       fr.onload = function() {
         var newAry = new Uint8Array(this.result);
@@ -82,12 +82,12 @@ describe('blob', function() {
     it('should enode mixed contents to right size', function() {
       var ary = new Uint8Array(5);
       for (var i = 0; i < 5; i++) ary[i] = i;
-      var b = new Blob([ary.buffer, 'hello']);
+      var b = blob([ary.buffer, 'hello']);
       expect(b.size).to.be(10);
     });
 
     it('should accept mime type', function() {
-      var b = new Blob(['hi', 'hello'], { type: 'text/html' });
+      var b = blob(['hi', 'hello'], { type: 'text/html' });
       expect(b.type).to.be('text/html');
     });
   }


### PR DESCRIPTION
Exporting the module as pretended Blob constructor is confusing since `blob instanceof Blob` doesn't work sometimes depending on environments. We can avoid the problem by using `blob instanceof global.Blob` but that doesn't make sense IMHO.

This becomes troublesome, especially since `instanceof` works fine in most cases. I think the problem would be solved if this module always exposes a function rather than constructor.
