### PR TITLE
avoid using global

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,11 @@
  * Create a blob builder even when vendor prefixes exist
  */
 
-var BlobBuilder = global.BlobBuilder
-  || global.WebKitBlobBuilder
-  || global.MSBlobBuilder
-  || global.MozBlobBuilder;
+var BlobBuilder = typeof BlobBuilder !== 'undefined' ? BlobBuilder :
+  typeof WebKitBlobBuilder !== 'undefined' ? WebKitBlobBuilder :
+  typeof MSBlobBuilder !== 'undefined' ? MSBlobBuilder :
+  typeof MozBlobBuilder !== 'undefined' ? MozBlobBuilder : 
+  false;
 
 /**
  * Check if Blob constructor is supported
@@ -83,14 +84,14 @@ function BlobConstructor(ary, options) {
   return new Blob(mapArrayBufferViews(ary), options || {});
 };
 
-if (global.Blob) {
+if (typeof Blob !== 'undefined') {
   BlobBuilderConstructor.prototype = Blob.prototype;
   BlobConstructor.prototype = Blob.prototype;
 }
 
 module.exports = (function() {
   if (blobSupported) {
-    return blobSupportsArrayBufferView ? global.Blob : BlobConstructor;
+    return blobSupportsArrayBufferView ? Blob : BlobConstructor;
   } else if (blobBuilderSupported) {
     return BlobBuilderConstructor;
   } else {


### PR DESCRIPTION
global is not standard in the browser (yet?), using it blocks using this lib with some build tools (e.g., angular-cli with socket.io imports)

see https://github.com/socketio/socket.io-client/issues/1166#issuecomment-386764202

@TooTallNate @nevir